### PR TITLE
Marathon Auth Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # dcos-adminrouter
 Nginx config running on the DCOS master servers to provide a proxy for the admin parts of the cluster
+
+Forked from https://github.com/dcos/dcos/tree/master/packages/adminrouter

--- a/extra/src/common/auth.lua
+++ b/extra/src/common/auth.lua
@@ -1,0 +1,185 @@
+local cjson = require "cjson"
+local jwt = require "resty.jwt"
+local cookiejar = require "resty.cookie"
+
+
+local util = require "common.util"
+
+
+local SECRET_KEY = nil
+local BODY_AUTH_ERROR_RESPONSE = nil
+
+local marathonhttpcred = os.getenv("MESOSPHERE_HTTP_CREDENTIALS")
+local errorpages_dir_path = os.getenv("AUTH_ERROR_PAGE_DIR_PATH")
+if errorpages_dir_path == nil then
+    ngx.log(ngx.WARN, "AUTH_ERROR_PAGE_DIR_PATH not set.")
+else
+    local p = errorpages_dir_path .. "/401.html"
+    ngx.log(ngx.NOTICE, "Reading 401 response from `" .. p .. "`.")
+    BODY_401_ERROR_RESPONSE = util.get_file_content(p)
+    if (BODY_401_ERROR_RESPONSE == nil or BODY_401_ERROR_RESPONSE == '') then
+        -- Normalize to '', for sending empty response bodies.
+        BODY_401_ERROR_RESPONSE = ''
+        ngx.log(ngx.WARN, "401 error response is empty.")
+    end
+    local p = errorpages_dir_path .. "/403.html"
+    ngx.log(ngx.NOTICE, "Reading 403 response from `" .. p .. "`.")
+    BODY_403_ERROR_RESPONSE = util.get_file_content(p)
+    if (BODY_403_ERROR_RESPONSE == nil or BODY_403_ERROR_RESPONSE == '') then
+        -- Normalize to '', for sending empty response bodies.
+        BODY_403_ERROR_RESPONSE = ''
+        ngx.log(ngx.WARN, "403 error response is empty.")
+    end
+end
+
+
+local key_file_path = os.getenv("SECRET_KEY_FILE_PATH")
+if key_file_path == nil then
+    ngx.log(ngx.WARN, "SECRET_KEY_FILE_PATH not set.")
+else
+    ngx.log(ngx.NOTICE, "Reading secret key from `" .. key_file_path .. "`.")
+    SECRET_KEY = util.get_stripped_first_line_from_file(key_file_path)
+    if (SECRET_KEY == nil or SECRET_KEY == '') then
+        -- Normalize to nil, for simplified subsequent per-request check.
+        SECRET_KEY = nil
+        ngx.log(ngx.WARN, "Secret key not set or empty string.")
+    end
+end
+
+
+-- Refs:
+-- https://github.com/openresty/lua-nginx-module#access_by_lua
+-- https://github.com/SkyLothar/lua-resty-jwt
+
+
+local function exit_401()
+    ngx.log(ngx.DEBUG, "ETHOS: exit 401 called")
+    ngx.status = ngx.HTTP_UNAUTHORIZED
+    ngx.header["Content-Type"] = "text/html; charset=UTF-8"
+    ngx.header["WWW-Authenticate"] = "oauthjwt"
+    ngx.say(BODY_401_ERROR_RESPONSE)
+    return ngx.exit(ngx.HTTP_UNAUTHORIZED)
+end
+
+
+local function exit_403()
+    ngx.status = ngx.HTTP_FORBIDDEN
+    ngx.header["Content-Type"] = "text/html; charset=UTF-8"
+    ngx.say(BODY_403_ERROR_RESPONSE)
+    return ngx.exit(ngx.HTTP_FORBIDDEN)
+end
+
+
+local function validate_jwt_or_exit()
+    -- Inspect Authorization header in current request. Expect JSON Web Token in
+    -- compliance with RFC 7519. Expect `uid` key in payload section. Extract
+    -- and return uid. In all other cases, terminate request handling and
+    -- respond with an appropriate HTTP error status code.
+
+    if SECRET_KEY == nil then
+        ngx.log(ngx.ERR, "Secret key not set. Cannot validate request.")
+        return exit_401()
+    end
+
+    local auth_header = ngx.var.http_Authorization
+    local token = nil
+    if auth_header ~= nil then
+        ngx.log(ngx.DEBUG, "Authorization header found. Attempt to extract token.")
+        if string.find(auth_header, "Basic") then
+          ngx.log(
+              ngx.DEBUG, "Basic authentication header found " ..
+              "override with token based authentication header."
+              )
+          local cookie, err = cookiejar:new()
+          token = cookie:get("dcos-acs-auth-cookie")
+          if token == nil then
+              ngx.log(ngx.DEBUG, "dcos-acs-auth-cookie not found.")
+          else
+              ngx.log(
+                  ngx.DEBUG, "Use token from dcos-acs-auth-cookie, " ..
+                  "set corresponding Authorization header for upstream."
+                  )
+              ngx.req.set_header("Authorization", "token=" .. token)
+          end
+        else
+          _, _, token = string.find(auth_header, "token=(.+)")
+        end
+    else
+        ngx.log(ngx.DEBUG, "Authorization header not found.")
+        -- Presence of Authorization header overrides cookie method entirely.
+        -- Read cookie. Note: ngx.var.cookie_* cannot access a cookie with a
+        -- dash in its name.
+        local cookie, err = cookiejar:new()
+        token = cookie:get("dcos-acs-auth-cookie")
+        if token == nil then
+            ngx.log(ngx.DEBUG, "dcos-acs-auth-cookie not found.")
+        else
+            ngx.log(
+                ngx.DEBUG, "Use token from dcos-acs-auth-cookie, " ..
+                "set corresponding Authorization header for upstream."
+                )
+            ngx.req.set_header("Authorization", "token=" .. token)
+        end
+    end
+
+    if token == nil then
+        ngx.log(ngx.NOTICE, "No auth token in request.")
+        ngx.log(ngx.DEBUG, "HEADERS: ".. ngx.req.raw_header())
+        return exit_401()
+    end
+
+    -- ngx.log(ngx.DEBUG, "Token: `" .. token .. "`")
+    -- Parse and verify token (also validate expiration time).
+    ngx.log(ngx.DEBUG, "HEADERS: ".. ngx.req.raw_header())
+    local jwt_obj = jwt:verify(SECRET_KEY, token)
+    ngx.log(ngx.DEBUG, "JSONnized JWT table: " .. cjson.encode(jwt_obj))
+    -- .verified is False even for messed up tokens whereas .valid can be nil.
+    -- So, use .verified as reference.
+    if jwt_obj.verified == false then
+        ngx.log(ngx.NOTICE, "Invalid token. Reason: ".. jwt_obj.reason)
+        return exit_401()
+    end
+
+    ngx.log(ngx.DEBUG, "Valid token. Extract UID from payload.")
+    local uid = jwt_obj.payload.uid
+
+    if uid == nil then
+        ngx.log(ngx.NOTICE, "Unexpected token payload: missing uid.")
+        return exit_401()
+    end
+
+    ngx.log(ngx.NOTICE, "UID from valid JWT: `".. uid .. "`")
+
+    res = ngx.location.capture("/acs/api/v1/users/" .. uid)
+    if res.status ~= ngx.HTTP_OK then
+        ngx.log(ngx.ERR, "User not found: `" .. uid .. "`")
+        return exit_401()
+    end
+    -- set authorization header back to basic
+    if auth_header ~= nil then
+        if string.find(auth_header, "Basic") then
+            ngx.log(ngx.DEBUG, "Setting authorization header back to basic.")
+            ngx.req.set_header("Authorization", auth_header)
+        else
+            if marathonhttpcred ~= nil then
+	        ngx.log(ngx.DEBUG, "auth_header is token type set authorization to basic.")
+	        ngx.req.set_header("Authorization" , "Basic " .. util.base64encode(marathonhttpcred))
+            end
+        end
+    else
+        if marathonhttpcred ~= nil then
+            ngx.log(ngx.DEBUG, "auth_header nil set authorization to basic.")
+            ngx.req.set_header("Authorization" , "Basic " .. util.base64encode(marathonhttpcred))
+        end
+    end
+
+    return uid
+end
+
+
+-- Expose interface.
+local _M = {}
+_M.validate_jwt_or_exit = validate_jwt_or_exit
+
+
+return _M

--- a/extra/src/common/http.conf
+++ b/extra/src/common/http.conf
@@ -1,0 +1,67 @@
+access_log syslog:server=unix:/dev/log;
+
+include mime.types;
+default_type application/octet-stream;
+sendfile on;
+keepalive_timeout 65;
+
+lua_package_path '$prefix/conf/?.lua;;';
+
+# Loading the auth module in the global Lua VM in the master process is a
+# requirement, so that code is executed under the user that spawns the
+# master process instead of 'nobody' (which workers operate under).
+init_by_lua '
+    util = require "common.util"
+    local use_auth = os.getenv("ADMINROUTER_ACTIVATE_AUTH_MODULE")
+    if use_auth ~= "true" then
+        ngx.log(
+            ngx.NOTICE,
+            "ADMINROUTER_ACTIVATE_AUTH_MODULE not `true`. " ..
+            "Use dummy module."
+            )
+        auth = {}
+        auth.validate_jwt_or_exit = function() return end
+    else
+        ngx.log(ngx.NOTICE, "Use auth module.")
+        auth = require "common.auth"
+    end
+
+    local marathonhttpauth = os.getenv("MESOSPHERE_HTTP_CREDENTIALS")
+    if marathonhttpauth ~= nil then
+      ngx.log(
+          ngx.NOTICE,
+          "MESOSPHERE_HTTP_CREDENTIALS is set"
+          )
+    else
+        ngx.log(ngx.NOTICE, "Marathon not using BASIC Authorization")
+    end
+
+    DEFAULT_SCHEME = os.getenv("DEFAULT_SCHEME")
+    if DEFAULT_SCHEME == nil then
+        DEFAULT_SCHEME = "http://"
+    end
+    ngx.log(ngx.NOTICE, "Default scheme: " .. DEFAULT_SCHEME)
+
+    UPSTREAM_MESOS = os.getenv("UPSTREAM_MESOS")
+    if UPSTREAM_MESOS == nil then
+        UPSTREAM_MESOS = "http://leader.mesos:5050"
+    end
+    ngx.log(ngx.NOTICE, "Mesos upstream: " .. UPSTREAM_MESOS)
+
+    UPSTREAM_MARATHON = os.getenv("UPSTREAM_MARATHON")
+    if UPSTREAM_MARATHON == nil then
+        UPSTREAM_MARATHON = "http://127.0.0.1:8080"
+    end
+    ngx.log(ngx.NOTICE, "Marathon upstream: " .. UPSTREAM_MARATHON)
+
+    -- Initialize cache:
+    cache = require "master.cache".init(nil);
+';
+
+upstream pkgpanda {
+    server unix:/run/dcos/pkgpanda-api.sock;
+}
+
+upstream log {
+    server unix:/run/dcos/dcos-log.sock;
+}

--- a/extra/src/common/main.conf
+++ b/extra/src/common/main.conf
@@ -1,0 +1,35 @@
+# Log info level messages and higher:
+# * state cache emits useful log messages on notice level
+# * some of the log messages that are required by test
+#   harness are not important enough to justify anything
+#   higher than info level.
+error_log stderr info;
+
+
+# Make env vars accessible from within Lua modules.
+env SECRET_KEY_FILE_PATH;
+env AUTH_ERROR_PAGE_DIR_PATH;
+env OAUTH_CLIENT_ID;
+env OAUTH_AUTH_REDIRECTOR;
+env DEFAULT_SCHEME;
+env UPSTREAM_MARATHON;
+env UPSTREAM_MESOS;
+
+env CACHE_FIRST_POLL_DELAY;
+env CACHE_POLL_PERIOD;
+env CACHE_EXPIRATION;
+env CACHE_MAX_AGE_SOFT_LIMIT;
+env CACHE_MAX_AGE_HARD_LIMIT;
+env CACHE_BACKEND_REQUEST_TIMEOUT;
+env CACHE_REFRESH_LOCK_TIMEOUT;
+
+env MESOSPHERE_HTTP_CREDENTIALS;
+
+
+events {
+    worker_connections 1024;
+}
+
+# Run worker processes in dcos_adminrouter group to
+# restrict access to unix socket files.
+user nobody dcos_adminrouter;

--- a/extra/src/common/util.lua
+++ b/extra/src/common/util.lua
@@ -1,0 +1,74 @@
+local cjson_safe = require "cjson.safe"
+
+
+local util = {}
+local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+function util.get_stripped_first_line_from_file(path)
+    -- Return nil when file is emtpy.
+    -- Return nil open I/O error.
+    -- Log I/O error details.
+    local f, err = io.open(path, "rb")
+    if f then
+        -- *l read mode: read line skipping EOL, return nil on end of file.
+        local line = f:read("*l")
+        f:close()
+        if line then
+            return line:strip()
+        end
+        ngx.log(ngx.ERR, "File is empty: " .. path)
+        return nil
+    end
+    ngx.log(ngx.ERR, "Error reading file `" .. path .. "`: " .. err)
+    return nil
+end
+
+
+function util.get_file_content(path)
+    local f, err = io.open(path, "rb")
+    if f then
+        -- *a read mode: read entire file.
+        local content = f:read("*a")
+        f:close()
+        return content
+    end
+    ngx.log(ngx.ERR, "Error reading file `" .. path .. "`: " .. err)
+    return nil
+end
+
+
+-- Monkey-patch string table.
+
+function string:split(sep)
+    local sep, fields = sep or " ", {}
+    local pattern = string.format("([^%s]+)", sep)
+    self:gsub(pattern, function(c) fields[#fields+1] = c end)
+    return fields
+end
+
+
+function string.startswith(str, prefix)
+    return string.sub(str, 1, string.len(prefix)) == prefix
+end
+
+
+function string:strip()
+    -- Strip leading and trailing whitespace.
+    -- Ref: http://lua-users.org/wiki/StringTrim
+    return self:match "^%s*(.-)%s*$"
+end
+
+function util.base64encode(data)
+    return ((data:gsub('.', function(x) 
+        local r,b='',x:byte()
+        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c=0
+        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
+        return b:sub(c+1,c+1)
+    end)..({ '', '==', '=' })[#data%3+1])
+end
+
+return util

--- a/extra/src/master/cache.lua
+++ b/extra/src/master/cache.lua
@@ -1,0 +1,526 @@
+local cjson_safe = require "cjson.safe"
+local shmlock = require "resty.lock"
+local http = require "resty.http"
+local marathonhttpcred = os.getenv("MESOSPHERE_HTTP_CREDENTIALS")
+
+local util = require "master.util"
+
+local _M = {}
+
+-- In order to make caching code testable, these constants need to be
+-- configurable/exposed through env vars.
+--
+-- Values assigned to these variable need to fufil following condition:
+--
+-- CACHE_FIRST_POLL_DELAY << CACHE_EXPIRATION < CACHE_POLL_PERIOD < CACHE_MAX_AGE_SOFT_LIMIT < CACHE_MAX_AGE_HARD_LIMIT
+--
+-- CACHE_BACKEND_REQUEST_TIMEOUT << CACHE_REFRESH_LOCK_TIMEOUT
+--
+-- All are in units of seconds. Below are the defaults:
+local _CONFIG = {}
+local env_vars = {CACHE_FIRST_POLL_DELAY = 2,
+                  CACHE_POLL_PERIOD = 25,
+                  CACHE_EXPIRATION = 20,
+                  CACHE_MAX_AGE_SOFT_LIMIT = 75,
+                  CACHE_MAX_AGE_HARD_LIMIT = 259200,
+                  CACHE_BACKEND_REQUEST_TIMEOUT = 10,
+                  CACHE_REFRESH_LOCK_TIMEOUT = 20,
+                  }
+
+for key, value in pairs(env_vars) do
+    -- yep, we are OK with key==nil, tonumber will just return nil
+    local env_var_val = tonumber(os.getenv(key))
+    if env_var_val == nil or env_var_val == value then
+        ngx.log(ngx.DEBUG, "Using default ".. key .. " value: `" .. value .. "` seconds")
+        _CONFIG[key] = value
+    else
+        ngx.log(ngx.NOTICE,
+                key .. " overridden by ENV to `" .. env_var_val .. "` seconds")
+        _CONFIG[key] = env_var_val
+    end
+end
+
+
+local function cache_data(key, value)
+    -- Store key/value pair to SHM cache (shared across workers).
+    -- Return true upon success, false otherwise.
+    -- Expected to run within lock context.
+
+    local cache = ngx.shared.cache
+    local success, err, forcible = cache:set(key, value)
+    if success then
+        return true
+    end
+    ngx.log(
+        ngx.ERR,
+        "Could not store " .. key .. " to state cache: " .. err
+        )
+    return false
+end
+
+
+local function request(url, accept_404_reply, auth_token)
+    local headers = {}
+    ngx.log(ngx.DEBUG, "ETHOS: request " .. url .. " being called")
+    if auth_token ~= nil then
+        ngx.log(ngx.DEBUG, "TEST: auth_token" .. auth_token)
+        headers = {["Authorization"] = "token=" .. auth_token}
+    end
+    if marathonhttpcred ~= nil then
+        ngx.log(ngx.DEBUG, "ETHOS: Marathon auth cred set")
+        if string.find(url, ":8080") then
+            ngx.log(ngx.DEBUG, "ETHOS: call to port 8080 marathon injecting BASIC auth header")
+            headers = {["Authorization"] = "Basic " .. util.base64encode(marathonhttpcred)}
+        end
+    end
+
+    -- Use cosocket-based HTTP library, as ngx subrequests are not available
+    -- from within this code path (decoupled from nginx' request processing).
+    -- The timeout parameter is given in milliseconds. The `request_uri`
+    -- method takes care of parsing scheme, host, and port from the URL.
+    local httpc = http.new()
+    httpc:set_timeout(_CONFIG.CACHE_BACKEND_REQUEST_TIMEOUT * 1000)
+    local res, err = httpc:request_uri(url, {
+        method="GET",
+        headers=headers,
+        ssl_verify=true
+    })
+
+    if not res then
+        return nil, err
+    end
+
+    if res.status ~= 200 then
+        if accept_404_reply and res.status ~= 404 or not accept_404_reply then
+            return nil, "invalid response status: " .. res.status
+        end
+    end
+
+    ngx.log(
+        ngx.NOTICE,
+        "Request url: " .. url .. " " ..
+        "Response Body length: " .. string.len(res.body) .. " bytes."
+        )
+
+    return res, nil
+end
+
+
+local function fetch_and_store_marathon_apps(auth_token)
+    -- Access Marathon through localhost.
+    ngx.log(ngx.NOTICE, "Cache Marathon app state")
+    local appsRes, err = request(UPSTREAM_MARATHON .. "/v2/apps?embed=apps.tasks&label=DCOS_SERVICE_NAME",
+                                 false,
+                                 auth_token)
+
+    if err then
+        ngx.log(ngx.NOTICE, "Marathon app request failed: " .. err)
+        return
+    end
+
+    local apps, err = cjson_safe.decode(appsRes.body)
+    if not apps then
+        ngx.log(ngx.WARN, "Cannot decode Marathon apps JSON: " .. err)
+        return
+    end
+
+    local svcApps = {}
+    for _, app in ipairs(apps["apps"]) do
+       local appId = app["id"]
+       local labels = app["labels"]
+       if not labels then
+          ngx.log(ngx.NOTICE, "Labels not found in app '" .. appId .. "'")
+          goto continue
+       end
+
+       -- Service name should exist as we asked Marathon for it
+       local svcId = labels["DCOS_SERVICE_NAME"]
+
+       local scheme = labels["DCOS_SERVICE_SCHEME"]
+       if not scheme then
+          ngx.log(ngx.NOTICE, "Cannot find DCOS_SERVICE_SCHEME for app '" .. appId .. "'")
+          goto continue
+       end
+
+       local portIdx = labels["DCOS_SERVICE_PORT_INDEX"]
+       if not portIdx then
+          ngx.log(ngx.NOTICE, "Cannot find DCOS_SERVICE_PORT_INDEX for app '" .. appId .. "'")
+          goto continue
+       end
+
+       local portIdx = tonumber(portIdx)
+       if not portIdx then
+          ngx.log(ngx.NOTICE, "Cannot convert port to number for app '" .. appId .. "'")
+          goto continue
+       end
+
+       -- Lua arrays default starting index is 1 not the 0 of marathon
+       portIdx = portIdx + 1
+
+       local tasks = app["tasks"]
+
+       -- Process only tasks in TASK_RUNNING state.
+       -- From http://lua-users.org/wiki/TablesTutorial: "inside a pairs loop,
+       -- it's safe to reassign existing keys or remove them"
+       for i, t in ipairs(tasks) do
+          if t["state"] ~= "TASK_RUNNING" then
+             table.remove(tasks, i)
+          end
+       end
+
+       -- next() returns nil if table is empty.
+       local i, task = next(tasks)
+       if i == nil then
+          ngx.log(ngx.NOTICE, "No task in state TASK_RUNNING for app '" .. appId .. "'")
+          goto continue
+       end
+
+       ngx.log(
+          ngx.NOTICE,
+          "Reading state for appId '" .. appId .. "' from task with id '" .. task["id"] .. "'"
+          )
+
+       local host = task["host"]
+       if not host then
+          ngx.log(ngx.NOTICE, "Cannot find host for app '" .. appId .. "'")
+          goto continue
+       end
+
+       local ports = task["ports"]
+       if not ports then
+          ngx.log(ngx.NOTICE, "Cannot find ports for app '" .. appId .. "'")
+          goto continue
+       end
+
+       local port = ports[portIdx]
+       if not port then
+          ngx.log(ngx.NOTICE, "Cannot find port at Marathon port index '" .. (portIdx - 1) .. "' for app '" .. appId .. "'")
+          goto continue
+       end
+
+       local url = scheme .. "://" .. host .. ":" .. port
+       svcApps[svcId] = {scheme=scheme, url=url}
+
+       ::continue::
+    end
+
+    svcApps_json = cjson_safe.encode(svcApps)
+
+    ngx.log(ngx.DEBUG, "Storing Marathon apps data to SHM.")
+    if not cache_data("svcapps", svcApps_json) then
+        ngx.log(ngx.ERR, "Storing marathon apps cache failed")
+        return
+    end
+
+    ngx.update_time()
+    local time_now = ngx.now()
+    if cache_data("svcapps_last_refresh", time_now) then
+        ngx.log(ngx.INFO, "Marathon apps cache has been successfully updated")
+    end
+
+    return
+end
+
+
+local function fetch_and_store_marathon_leader(auth_token)
+    -- Fetch Marathon leader address. If successful, store to SHM cache.
+    -- Expected to run within lock context.
+    local mleaderRes, err = request(UPSTREAM_MARATHON .. "/v2/leader",
+                                    true,
+                                    auth_token)
+
+    if err then
+        ngx.log(ngx.WARN, "Marathon leader request failed: " .. err)
+        return
+    end
+
+    -- We need to translate 404 reply into a JSON that is easy to process for
+    -- endpoints:
+    -- https://mesosphere.github.io/marathon/docs/rest-api.html#get-v2-leader
+    local res_body
+    if mleaderRes.status == 404 then
+        -- Just a hack in order to avoid using gotos - create a substitute JSON
+        -- that can be parsed and processed by normal execution path and at the
+        -- same time passes the information of a missing Marathon leader.
+        ngx.log(ngx.NOTICE, "Using empty Marathon leader JSON")
+        res_body = '{"leader": "not elected:0"}'
+    else
+        res_body = mleaderRes.body
+    end
+
+    local mleader, err = cjson_safe.decode(res_body)
+    if not mleader then
+        ngx.log(ngx.WARN, "Cannot decode Marathon leader JSON: " .. err)
+        return
+    end
+
+    local split_mleader = mleader['leader']:split(":")
+    local parsed_mleader = {}
+    parsed_mleader["address"] = split_mleader[1]
+    parsed_mleader["port"] = split_mleader[2]
+    local mleader = cjson_safe.encode(parsed_mleader)
+
+    ngx.log(ngx.DEBUG, "Storing Marathon leader to SHM")
+    if not cache_data("marathonleader", mleader) then
+        ngx.log(ngx.ERR, "Storing Marathon leader cache failed")
+        return
+    end
+
+    ngx.update_time()
+    local time_now = ngx.now()
+    if cache_data("marathonleader_last_refresh", time_now) then
+        ngx.log(ngx.INFO, "Marathon leader cache has been successfully updated")
+    end
+
+    return
+end
+
+
+local function fetch_and_store_state_mesos(auth_token)
+    -- Fetch state JSON summary from Mesos. If successful, store to SHM cache.
+    -- Expected to run within lock context.
+    local mesosRes, err = request(UPSTREAM_MESOS .. "/master/state-summary",
+                                  false,
+                                  auth_token)
+
+    if err then
+        ngx.log(ngx.NOTICE, "Mesos state request failed: " .. err)
+        return
+    end
+
+    ngx.log(ngx.DEBUG, "Storing Mesos state to SHM.")
+    if not cache_data("mesosstate", mesosRes.body) then
+        ngx.log(ngx.WARN, "Storing mesos state cache failed")
+        return
+    end
+
+    ngx.update_time()
+    local time_now = ngx.now()
+    if cache_data("mesosstate_last_refresh", time_now) then
+        ngx.log(ngx.INFO, "Mesos state cache has been successfully updated")
+    end
+
+    return
+end
+
+
+local function refresh_needed(ts_name)
+    -- ts_name (str): name of the '*_last_refresh' timestamp to check
+    local cache = ngx.shared.cache
+
+    local last_fetch_time = cache:get(ts_name)
+    -- Handle the special case of first invocation.
+    if not last_fetch_time then
+        ngx.log(ngx.INFO, "Cache `".. ts_name .. "` empty. Fetching.")
+        return true
+    end
+
+    ngx.update_time()
+    local cache_age = ngx.now() - last_fetch_time
+    if cache_age > _CONFIG.CACHE_EXPIRATION then
+        ngx.log(ngx.INFO, "Cache `".. ts_name .. "` expired. Refresh.")
+        return true
+    end
+
+    ngx.log(ngx.DEBUG, "Cache `".. ts_name .. "` populated and fresh. NOOP.")
+
+    return false
+end
+
+
+local function refresh_cache(from_timer, auth_token)
+    -- Refresh cache in case when it expired or has not been created yet.
+    -- Use SHM-based lock for synchronizing coroutines across worker processes.
+    --
+    -- This function can be invoked via two mechanisms:
+    --
+    --  * Via ngx.timer (in a coroutine), which is triggered
+    --    periodically in all worker processes for performing an
+    --    out-of-band cache refresh (this is the usual mode of operation).
+    --    In that case, perform cache invalidation only if no other timer
+    --    instance currently does so (abort if lock cannot immediately be
+    --    acquired).
+    --
+    --  * During HTTP request processing, when cache content is
+    --    required for answering the request but the cache was not
+    --    populated yet (i.e. usually early after nginx startup).
+    --    In that case, return from this function only after the cache
+    --    has been populated (block on lock acquisition).
+    --
+    -- Args:
+    --      from_timer: set to true if invoked from a timer
+
+    -- Acquire lock.
+    local lock
+    -- In order to avoid deadlocks, we are relying on `exptime` param of
+    -- resty.lock (https://github.com/openresty/lua-resty-lock#new)
+    --
+    -- It's value is maximum time it may take to fetch data from all the
+    -- backends (ATM 2xMarathon + Mesos) plus an arbitrary two seconds period
+    -- just to be on the safe side.
+    local lock_ttl = 3 * (_CONFIG.CACHE_BACKEND_REQUEST_TIMEOUT + 2)
+
+    if from_timer then
+        ngx.log(ngx.INFO, "Executing cache refresh triggered by timer")
+        -- Fail immediately if another worker currently holds
+        -- the lock, because a single timer-based update at any
+        -- given time suffices.
+        lock = shmlock:new("shmlocks", {timeout=0, exptime=lock_ttl})
+        local elapsed, err = lock:lock("cache")
+        if elapsed == nil then
+            ngx.log(ngx.INFO, "Timer-based update is in progress. NOOP.")
+            return
+        end
+    else
+        ngx.log(ngx.INFO, "Executing cache refresh triggered by request")
+        -- Cache content is required for current request
+        -- processing. Wait for lock acquisition, for at
+        -- most 20 seconds.
+        lock = shmlock:new("shmlocks", {timeout=_CONFIG.CACHE_REFRESH_LOCK_TIMEOUT,
+                                        exptime=lock_ttl })
+        local elapsed, err = lock:lock("cache")
+        if elapsed == nil then
+            ngx.log(ngx.ERR, "Could not acquire lock: " .. err)
+            -- Leave early (did not make sure that cache is populated).
+            return
+        end
+    end
+
+    if refresh_needed("mesosstate_last_refresh") then
+        fetch_and_store_state_mesos(auth_token)
+    end
+
+    if refresh_needed("svcapps_last_refresh") then
+        fetch_and_store_marathon_apps(auth_token)
+    end
+
+    if refresh_needed("marathonleader_last_refresh") then
+        fetch_and_store_marathon_leader(auth_token)
+    end
+
+    local ok, err = lock:unlock()
+    if not ok then
+        -- If this fails, an unlock happens automatically via `exptime` lock
+        -- param described earlier.
+        ngx.log(ngx.ERR, "Failed to unlock cache shmlock: " .. err)
+    end
+end
+
+
+local function periodically_refresh_cache(auth_token)
+    -- This function is invoked from within init_worker_by_lua code.
+    -- ngx.timer.at() can be called here, whereas most of the other ngx.*
+    -- API is not available.
+
+    timerhandler = function(premature)
+        -- Handler for recursive timer invocation.
+        -- Within a timer callback, plenty of the ngx.* API is available,
+        -- with the exception of e.g. subrequests. As ngx.sleep is also not
+        -- available in the current context, the recommended approach of
+        -- implementing periodic tasks is via recursively defined timers.
+
+        -- Premature timer execution: worker process tries to shut down.
+        if premature then
+            return
+        end
+
+        -- Invoke timer business logic.
+        refresh_cache(true, auth_token)
+
+        -- Register new timer.
+        local ok, err = ngx.timer.at(_CONFIG.CACHE_POLL_PERIOD, timerhandler)
+        if not ok then
+            ngx.log(ngx.ERR, "Failed to create timer: " .. err)
+        else
+            ngx.log(ngx.INFO, "Created recursive timer for cache updating.")
+        end
+    end
+
+    -- Trigger initial timer, about CACHE_FIRST_POLL_DELAY seconds after
+    -- Nginx startup.
+    local ok, err = ngx.timer.at(_CONFIG.CACHE_FIRST_POLL_DELAY, timerhandler)
+    if not ok then
+        ngx.log(ngx.ERR, "Failed to create timer: " .. err)
+        return
+    else
+        ngx.log(ngx.INFO, "Created initial recursive timer for cache updating.")
+    end
+end
+
+
+local function get_cache_entry(name, auth_token)
+    local cache = ngx.shared.cache
+    local name_last_refresh = name .. "_last_refresh"
+
+    -- Handle the special case of very early request - before the first
+    -- timer-based cache refresh
+    local entry_last_refresh = cache:get(name_last_refresh)
+    if entry_last_refresh == nil then
+        refresh_cache(false, auth_token)
+
+        entry_last_refresh = cache:get(name .. "_last_refresh")
+        if entry_last_refresh == nil then
+            -- Something is really broken, abort!
+            ngx.log(ngx.ERR, "Could not retrieve last refresh time for `" .. name .. "` cache entry")
+            return nil
+        end
+    end
+
+    -- Check the clock
+    ngx.update_time()
+    local cache_age = ngx.now() - entry_last_refresh
+
+    -- Cache is too old, we can't use it:
+    if cache_age > _CONFIG.CACHE_MAX_AGE_HARD_LIMIT then
+        ngx.log(ngx.ERR, "Cache entry `" .. name .. "` is too old, aborting request")
+        return nil
+    end
+
+    -- Cache is stale, but still usable:
+    if cache_age > _CONFIG.CACHE_MAX_AGE_SOFT_LIMIT then
+        ngx.log(ngx.NOTICE, "Using stale `" .. name .. "` cache entry to fulfill the request")
+    end
+
+    local entry_json = cache:get(name)
+    if entry_json == nil then
+        ngx.log(ngx.ERR, "Could not retrieve `" .. name .. "` cache entry from SHM")
+        return nil
+    end
+
+    local entry, err = cjson_safe.decode(entry_json)
+    if entry == nil then
+        ngx.log(ngx.ERR, "Cannot decode JSON for entry `" .. entry_json .. "`: " .. err)
+        return nil
+    end
+
+    return entry
+end
+
+
+-- Expose Admin Router cache interface
+local _M = {}
+function _M.init(auth_token)
+    -- At some point auth_token passing will be refactored out in
+    -- favour of service accounts support.
+    local res = {}
+
+    if auth_token ~= nil then
+        -- auth_token variable is needed by a few functions which are
+        -- nested inside top-level ones. We can either define all the functions
+        -- inside the same lexical block, or we pass it around. Passing it
+        -- around seems cleaner.
+        res.get_cache_entry = function (name)
+            return get_cache_entry(name, auth_token)
+        end
+        res.periodically_refresh_cache = function()
+            return periodically_refresh_cache(auth_token)
+        end
+    else
+        res.get_cache_entry = get_cache_entry
+        res.periodically_refresh_cache = periodically_refresh_cache
+    end
+
+    return res
+end
+
+return _M

--- a/extra/src/master/util.lua
+++ b/extra/src/master/util.lua
@@ -1,0 +1,42 @@
+local cjson_safe = require "cjson.safe"
+
+local util = {}
+local b='ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+function util.mesos_dns_get_srv(framework_name)
+    local res = ngx.location.capture(
+        "/mesos_dns/v1/services/_" .. framework_name .. "._tcp.marathon.mesos")
+
+    if res.truncated then
+        -- Remote connection dropped prematurely or timed out.
+        ngx.log(ngx.ERR, "Request to Mesos DNS failed.")
+        return nil
+    end
+    if res.status ~= 200 then
+        ngx.log(ngx.ERR, "Mesos DNS response status: " .. res.status)
+        return nil
+    end
+
+    local records, err = cjson_safe.decode(res.body)
+    if not records then
+        ngx.log(ngx.ERR, "Cannot decode JSON: " .. err)
+        return nil
+    end
+    return records
+end
+
+function util.base64encode(data)
+    return ((data:gsub('.', function(x) 
+        local r,b='',x:byte()
+        for i=8,1,-1 do r=r..(b%2^i-b%2^(i-1)>0 and '1' or '0') end
+        return r;
+    end)..'0000'):gsub('%d%d%d?%d?%d?%d?', function(x)
+        if (#x < 6) then return '' end
+        local c=0
+        for i=1,6 do c=c+(x:sub(i,i)=='1' and 2^(6-i) or 0) end
+        return b:sub(c+1,c+1)
+    end)..({ '', '==', '=' })[#data%3+1])
+end
+
+
+return util


### PR DESCRIPTION
Changes to adminrouter package to support marathon basic authentication.

1. cache.lua changes are for backend marathon calls from the adminrouter UI. i.e. dashboard.
2. auth.lua changes are for auth calls to validation calls from dcos cli and some to ensure UI behavior still works properly without prompting for mesosphere credentals in marathon.
3. http.conf and main.conf are to read in environment variables for marathon basic auth.
4. util.lua changes to base64 encoding of authentication headers.