### PR TITLE
Admin Router: Prevent reusing tcp sockets by AR's cache code [1.9]

### DIFF
--- a/extra/src/master/cache.lua
+++ b/extra/src/master/cache.lua
@@ -61,7 +61,14 @@ end
 
 
 local function request(url, accept_404_reply, auth_token)
-    local headers = {}
+    -- We need to make sure that Nginx does not reuse the TCP connection here,
+    -- as i.e. during failover it could result in fetching data from e.g. Mesos
+    -- master which already abdicated. On top of that we also need to force
+    -- re-resolving leader.mesos address which happens during the setup of the
+    -- new connection.
+    local headers = {
+        ["Connection"] = "close",
+    }
     if auth_token ~= nil then
         headers = {["Authorization"] = "token=" .. auth_token}
     end


### PR DESCRIPTION
Upstream changes for 1.9.
https://github.com/dcos/dcos/pull/2539